### PR TITLE
fix: Make build work for python_3.11

### DIFF
--- a/crawl-ref/source/util/species-gen.py
+++ b/crawl-ref/source/util/species-gen.py
@@ -6,8 +6,12 @@ import argparse
 import os
 import sys
 import traceback
-import collections
 import re
+import collections
+if sys.version_info.major == 2:
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
 
 import yaml  # pip install pyyaml
 
@@ -17,7 +21,7 @@ def quote_or_nullptr(key, d):
     else:
         return 'nullptr'
 
-class Species(collections.MutableMapping):
+class Species(MutableMapping):
     """Parser for YAML definition files.
 
     If any YAML content is invalid, the relevant parser function below should


### PR DESCRIPTION
A quick PR to fix this error I met while trying to build (Python3.11 on Debian 12):

```python
Traceback (most recent call last):
  File "/var/local/crawl-dev/dgamelaunch-config/crawl-build/crawl-git-repository/crawl-ref/source/util/species-gen.py", line 20, in <module>
    class Species(collections.MutableMapping):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'MutableMapping'
```

I haven't check if the game runs well, but it builds fine with my setup. You should ensure it also build with older Python versions before merging.